### PR TITLE
Add export to clipboard functionality

### DIFF
--- a/colonization/colonization.py
+++ b/colonization/colonization.py
@@ -2,6 +2,7 @@ import csv
 import json
 import re
 import os
+import tkinter as tk
 from os import path
 from typing import Any, Optional
 
@@ -285,6 +286,7 @@ class ColonizationPlugin:
         ui.on('next', self.next_construction)
         ui.on('track', self.track_station)
         ui.on('update', self.update_display)
+        ui.on('export', self.export_current)
         self.update_display()
 
     def prev_construction(self, event: Any) -> None:
@@ -366,6 +368,20 @@ class ColonizationPlugin:
             self.currentConstruction = None
         self.update_display()
         self.save()
+
+    def export_current(self, event: Any) -> None:
+        fields = ['name', 'buy', 'demand', 'cargo', 'carrier']
+        stringValue = '\t'.join(fields) + '\n'
+        data = self.get_table()
+        for commodity in data:
+            stringValue += commodity.export() + '\n'
+        # Use tkinter to handle clipboard operations
+        root = tk.Tk()
+        root.withdraw()  # Hide the main tkinter window
+        root.clipboard_clear()
+        root.clipboard_append(stringValue)
+        root.update()  # Ensure clipboard is updated
+        root.destroy()
 
     @classmethod
     def commodity_from_name(cls, name: str) -> str:

--- a/colonization/data.py
+++ b/colonization/data.py
@@ -43,3 +43,7 @@ class TableEntry:
         if result < 0:
             result = 0
         return result
+    
+    def export(self) -> str:
+        result = self.commodity.name + '\t' + str(self.buy()) + '\t' + str(self.demand) + '\t' + str(self.cargo) + '\t' + str(self.carrier)
+        return result

--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -65,6 +65,7 @@ class MainUi:
         self.station: Optional[tk.Label] = None
         self.total_label: Optional[tk.Label] = None
         self.track_btn: Optional[tk.Button] = None
+        self.export_btn: Optional[tk.Button] = None
         self.prev_btn: Optional[tk.Label] = None
         self.next_btn: Optional[tk.Label] = None
         self.view_btn: Optional[tk.Label] = None
@@ -156,6 +157,9 @@ class MainUi:
                 label.grid_remove()
             self.rows.append(labels)
 
+        self.export_btn = tk.Button(self.frame, text=ptl('Copy to clipboard'), command=partial(self.event, "export", None))
+        self.export_btn.grid(row=self.next_row(), column=0, sticky=tk.EW, columnspan=5)
+        
         theme.update(self.table_frame)
         theme.update(self.frame)
 


### PR DESCRIPTION
This adds a button at the bottom of the table and additional functions to allow copying the current table data (not just the displayed data) to the clipboard.