### PR TITLE
Make list be copyable and pastable to Excel

### DIFF
--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -255,7 +255,6 @@ class MainUi:
         # Create context menu
         context_menu = tk.Menu(self.table_frame, tearoff=0)
         context_menu.add_command(label="Copy Table", command=lambda: self._copy_table_text(None))
-        context_menu.add_separator()
         
         try:
             context_menu.tk_popup(event.x_root, event.y_root)

--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -137,7 +137,6 @@ class MainUi:
         
         # Make the frame focusable and enable text selection
         self.table_frame.focus_set()
-        self.table_frame.bind("<Control-a>", self._select_all_table_text)
         self.table_frame.bind("<Control-c>", self._copy_table_text)
         self.table_frame.bind("<Button-3>", self._show_context_menu)  # Right-click menu
 
@@ -240,11 +239,6 @@ class MainUi:
         if self.top_rows <= 1:
             self.top_rows = 0
         self.event('update', None)
-
-    def _select_all_table_text(self, event):
-        """Enable selecting all table text with Ctrl+A"""
-        # This method prepares for copying - actual copy will happen with Ctrl+C
-        return "break"
     
     def _on_label_click(self, event):
         """Handle label click for selection"""
@@ -262,7 +256,6 @@ class MainUi:
         context_menu = tk.Menu(self.table_frame, tearoff=0)
         context_menu.add_command(label="Copy Table", command=lambda: self._copy_table_text(None))
         context_menu.add_separator()
-        context_menu.add_command(label="Select All", command=lambda: self._select_all_table_text(None))
         
         try:
             context_menu.tk_popup(event.x_root, event.y_root)
@@ -272,17 +265,16 @@ class MainUi:
         return "break"
     
     def _copy_table_text(self, event):
-        """Copy visible table content to clipboard"""
+        """Copy visible table content to clipboard in Excel-compatible tab-separated format"""
         if not self.rows or not self.table_frame:
             return "break"
             
         # Collect visible table data
         table_lines = []
         
-        # Add header
-        header = f"{'Commodity':<30} {'Buy':>10} {'Demand':>10} {'Carrier':>10} {'Cargo':>10}"
+        # Add header with tab separation for Excel compatibility
+        header = "Commodity\tBuy\tDemand\tCarrier\tCargo"
         table_lines.append(header)
-        table_lines.append("-" * len(header))
         
         # Add visible rows
         for row_labels in self.rows:
@@ -297,7 +289,14 @@ class MainUi:
                 carrier = row_labels['carrier'].cget('text') if row_labels['carrier'].winfo_viewable() else ""
                 cargo = row_labels['cargo'].cget('text') if row_labels['cargo'].winfo_viewable() else ""
                 
-                line = f"{name:<30} {buy:>10} {demand:>10} {carrier:>10} {cargo:>10}"
+                # Remove commas from numbers for Excel compatibility
+                buy_clean = buy.replace(',', '') if buy else ""
+                demand_clean = demand.replace(',', '') if demand else ""
+                carrier_clean = carrier.replace(',', '') if carrier else ""
+                cargo_clean = cargo.replace(',', '') if cargo else ""
+                
+                # Use tab separation for Excel compatibility
+                line = f"{name}\t{buy_clean}\t{demand_clean}\t{carrier_clean}\t{cargo_clean}"
                 table_lines.append(line)
         
         # Copy to clipboard

--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -131,7 +131,7 @@ class MainUi:
         self.track_btn.grid(row=self.next_row(), column=0, sticky=tk.EW, columnspan=5)
 
         self.table_frame = tk.Frame(self.frame, highlightthickness=1, highlightcolor="blue", 
-                                   relief="ridge", borderwidth=1, cursor="gobbler")
+                                   relief="ridge", borderwidth=1)
         self.table_frame.columnconfigure(0, weight=1)
         self.table_frame.grid(row=self.next_row(), column=0, sticky=tk.EW)
         
@@ -142,11 +142,11 @@ class MainUi:
 
         # Create header labels with selection support
         header_labels = [
-            tk.Label(self.table_frame, text=ptl("Commodity"), cursor="gobbler"),
-            tk.Label(self.table_frame, text=ptl("Buy"), cursor="gobbler"),
-            tk.Label(self.table_frame, text=ptl("Demand"), cursor="gobbler"),
-            tk.Label(self.table_frame, text=ptl("Carrier"), cursor="gobbler"),
-            tk.Label(self.table_frame, text=ptl("Cargo"), cursor="gobbler")
+            tk.Label(self.table_frame, text=ptl("Commodity")),
+            tk.Label(self.table_frame, text=ptl("Buy")),
+            tk.Label(self.table_frame, text=ptl("Demand")),
+            tk.Label(self.table_frame, text=ptl("Carrier")),
+            tk.Label(self.table_frame, text=ptl("Cargo"))
         ]
         
         # Grid and bind header labels
@@ -166,11 +166,11 @@ class MainUi:
         for i in range(self.ROWS):
             self.table_frame.grid_rowconfigure(i+1, pad=0)
             labels = {
-                'name': tk.Label(self.table_frame, anchor=tk.W, font=fontDefault, justify=tk.LEFT, cursor="gobbler"),
-                'buy': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler"),
-                'demand': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler"),
-                'cargo': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler"),
-                'carrier': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler")
+                'name': tk.Label(self.table_frame, anchor=tk.W, font=fontDefault, justify=tk.LEFT),
+                'buy': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
+                'demand': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
+                'cargo': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
+                'carrier': tk.Label(self.table_frame, anchor=tk.E, font=fontMono)
             }
             # Make labels selectable and focusable
             for label in labels.values():

--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -143,11 +143,11 @@ class MainUi:
 
         # Create header labels with selection support
         header_labels = [
-            tk.Label(self.table_frame, text=ptl("Commodity"), cursor="text"),
-            tk.Label(self.table_frame, text=ptl("Buy"), cursor="text"),
-            tk.Label(self.table_frame, text=ptl("Demand"), cursor="text"),
-            tk.Label(self.table_frame, text=ptl("Carrier"), cursor="text"),
-            tk.Label(self.table_frame, text=ptl("Cargo"), cursor="text")
+            tk.Label(self.table_frame, text=ptl("Commodity"), cursor="gobbler"),
+            tk.Label(self.table_frame, text=ptl("Buy"), cursor="gobbler"),
+            tk.Label(self.table_frame, text=ptl("Demand"), cursor="gobbler"),
+            tk.Label(self.table_frame, text=ptl("Carrier"), cursor="gobbler"),
+            tk.Label(self.table_frame, text=ptl("Cargo"), cursor="gobbler")
         ]
         
         # Grid and bind header labels
@@ -167,11 +167,11 @@ class MainUi:
         for i in range(self.ROWS):
             self.table_frame.grid_rowconfigure(i+1, pad=0)
             labels = {
-                'name': tk.Label(self.table_frame, anchor=tk.W, font=fontDefault, justify=tk.LEFT, cursor="text"),
-                'buy': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="text"),
-                'demand': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="text"),
-                'cargo': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="text"),
-                'carrier': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="text")
+                'name': tk.Label(self.table_frame, anchor=tk.W, font=fontDefault, justify=tk.LEFT, cursor="gobbler"),
+                'buy': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler"),
+                'demand': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler"),
+                'cargo': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler"),
+                'carrier': tk.Label(self.table_frame, anchor=tk.E, font=fontMono, cursor="gobbler")
             }
             # Make labels selectable and focusable
             for label in labels.values():

--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -131,7 +131,7 @@ class MainUi:
         self.track_btn.grid(row=self.next_row(), column=0, sticky=tk.EW, columnspan=5)
 
         self.table_frame = tk.Frame(self.frame, highlightthickness=1, highlightcolor="blue", 
-                                   relief="ridge", borderwidth=1, cursor="text")
+                                   relief="ridge", borderwidth=1, cursor="gobbler")
         self.table_frame.columnconfigure(0, weight=1)
         self.table_frame.grid(row=self.next_row(), column=0, sticky=tk.EW)
         


### PR DESCRIPTION
This pull request enhances the usability of the table in the `colonization/ui.py` UI by making the table content easily selectable and copyable, especially for use in spreadsheet applications like Excel. It also improves the table's visual appearance and interaction handling. The most important changes are grouped below:

**Table Interactivity and Copy Functionality:**

* Added support for selecting and copying table contents via keyboard shortcut (`Ctrl+C`) and a right-click context menu, making it easy to export visible table data in an Excel-compatible, tab-separated format. This includes new helper methods: `_on_label_click`, `_show_context_menu`, and `_copy_table_text`. [[1]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fL131-R165) [[2]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fR175-R179) [[3]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fR243-R309)
* Made all header and cell labels focusable and selectable, and ensured that clicking or right-clicking on them enables selection or shows the copy menu. [[1]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fL131-R165) [[2]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fR175-R179)

**Visual and Structural Improvements:**

* Enhanced the appearance of the table frame by adding a blue border and ridge relief for clearer separation in the UI.
* Updated the type annotation for `self.rows` to be more specific (`list[dict[str, tk.Label]]`) and used `# type: ignore` to suppress type checker warnings where necessary. [[1]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fL62-R62) [[2]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fL131-R165)

**Robustness and Defensive Programming:**

* Added checks to ensure that operations on `self.frame` and `self.table_frame` only occur if these widgets exist, preventing potential runtime errors. [[1]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fR95-R96) [[2]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fR384) [[3]](diffhunk://#diff-ccfe507b8ff5e2f1f14e50e2cc16eda4e211c5a7c79bfee04729bb7fdfc1622fR446-R449)