### PR TITLE
Add optional profit calculations

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,19 +5,24 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+    - name: Clone EDMC
+      uses: actions/checkout@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        repository: EDMC/EDMarketConnector
+        path: EDMC
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        cache: 'pip'
+        python-version-file: 'EDMC/.python-version'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+    - name: Set Environment
+      run: echo "PYTHONPATH=.:./EDMC" >> $GITHUB_ENV
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint $(git ls-files '*.py') --output-format=github

--- a/colonization/colonization.py
+++ b/colonization/colonization.py
@@ -35,6 +35,7 @@ class ColonizationPlugin:
         self.dockedConstruction = False
         self.markets: dict[str, list[str]] = {}
         self.currentMarketId = None
+        self.profits: dict[str, list[int]] = {}
         logger.debug("initialized")
 
     def plugin_start3(self, plugin_dir: str) -> None:
@@ -186,13 +187,26 @@ class ColonizationPlugin:
         needed = self.currentConstruction.required if self.currentConstruction else self.get_total_shopping_list()
         table: list[TableEntry] = []
         local_commodities: list[str] = self.markets.get(self.currentMarketId, []) if self.currentMarketId else []
+        calc_profits = Config.CALC_PROFITS.get()
         for commodity, required in needed.items():
+            not_in_profits = commodity not in self.profits
+            instance_of_resource = isinstance(required, ConstructionResource)
+            in_local = commodity in local_commodities
+            if calc_profits:
+                if not_in_profits:
+                    self.profits[commodity] = [0, 0]
+                if instance_of_resource and in_local:
+                    self.profits[commodity][0] = required.payment - local_commodities[commodity]
+                    self.profits[commodity][1] = self.profits[commodity][0] * min(self.maxcargo, required.needed())
+            profits = self.profits.get(commodity, [None, None])
             table.append(TableEntry(
                 commodity=self.commodityMap[commodity],
                 demand=required.needed() if isinstance(required, ConstructionResource) else required,
                 cargo=self.cargo.get(commodity, 0),
                 carrier=self.carrier.get(commodity),
-                available=commodity in local_commodities
+                available=commodity in local_commodities,
+                cr_ton=profits[0],
+                cr_trip=profits[1],
             ))
         return table
 

--- a/colonization/config.py
+++ b/colonization/config.py
@@ -8,6 +8,7 @@ from config import config as edmc_config
 PREFIX="colonization."
 
 class Config(Enum):
+    CALC_PROFITS = f"{PREFIX}calcProfits", bool, True
     IGNORE_FC_UPDATE=f"{PREFIX}ignoreFCUpdate", bool, True
     SHOW_STATION_NAME = f"{PREFIX}showStationName", bool, True
     SHOW_TOTALS = f"{PREFIX}showTotals", bool, True

--- a/colonization/data.py
+++ b/colonization/data.py
@@ -22,12 +22,14 @@ class Commodity:
 
 
 class TableEntry:
-    def __init__(self, commodity:Commodity, demand:int, cargo:int, carrier:int, available:bool):
+    def __init__(self, commodity:Commodity, demand:int, cargo:int, carrier:int, available:bool, cr_ton:int, cr_trip:int):
         self.commodity = commodity
         self.demand = demand
         self.cargo = cargo
         self.carrier = carrier
         self.available = available
+        self.cr_ton = cr_ton
+        self.cr_trip = cr_trip
 
     def category(self):
         return self.commodity.category

--- a/colonization/preferencesui.py
+++ b/colonization/preferencesui.py
@@ -24,6 +24,7 @@ class PreferencesUi:
         self.frame: Optional[ttk.Frame] = None
         self.fc_callsign: Optional[tk.Label] = None
         self.fc_last_update: Optional[tk.Label] = None
+        self.calc_profits: Optional[tk.Variable] = None
         self.construction_list: Optional[ttk.Frame] = None
         self.ignore_fc_update: Optional[tk.Variable] = None
         self.show_station_name: Optional[tk.Variable] = None
@@ -59,6 +60,10 @@ class PreferencesUi:
 
         self.show_totals = Config.SHOW_TOTALS.tk_var()
         nb.Checkbutton(self.frame, text=ptl("Show totals line"), variable=self.show_totals).grid(
+            row=self.next_row(), sticky=tk.W, padx=self.PAD_X)
+
+        self.calc_profits = Config.CALC_PROFITS.tk_var()
+        nb.Checkbutton(self.frame, text=ptl("Calculate profits"), variable=self.calc_profits).grid(
             row=self.next_row(), sticky=tk.W, padx=self.PAD_X)
 
         self.var_categories = Config.CATEGORIES.tk_var()
@@ -147,6 +152,8 @@ class PreferencesUi:
             Config.SHOW_TOTALS.set(self.show_totals.get())
         if self.show_station_name:
             Config.SHOW_STATION_NAME.set(self.show_station_name.get())
+        if self.calc_profits:
+            Config.CALC_PROFITS.set(self.calc_profits.get())
 
         self.plugin.update_language()
         self.plugin.update_display()

--- a/colonization/ui.py
+++ b/colonization/ui.py
@@ -137,6 +137,8 @@ class MainUi:
         tk.Label(self.table_frame, text=ptl("Demand")).grid(row=0, column=2, sticky=tk.E)
         tk.Label(self.table_frame, text=ptl("Carrier")).grid(row=0, column=3, sticky=tk.E)
         tk.Label(self.table_frame, text=ptl("Cargo")).grid(row=0, column=4, sticky=tk.E)
+        tk.Label(self.table_frame, text=ptl("Cr/Ton")).grid(row=0, column=5, sticky=tk.E)
+        tk.Label(self.table_frame, text=ptl("Cr/Trip")).grid(row=0, column=6, sticky=tk.E)
 
         fontDefault = ("Tahoma", 9, "normal")
         fontMono = ("Tahoma", 9, "normal")
@@ -149,7 +151,9 @@ class MainUi:
                 'buy': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
                 'demand': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
                 'cargo': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
-                'carrier': tk.Label(self.table_frame, anchor=tk.E, font=fontMono)
+                'carrier': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
+                'cr_ton': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
+                'cr_trip': tk.Label(self.table_frame, anchor=tk.E, font=fontMono),
             }
             labels['name'].grid_configure(sticky=tk.W)
             for label in labels.values():
@@ -237,6 +241,8 @@ class MainUi:
         self.rows[row]['name'].grid(row=row+1, column=0)
         self.rows[row]['cargo'].grid_remove()
         self.rows[row]['carrier'].grid_remove()
+        self.rows[row]['cr_ton'].grid_remove()
+        self.rows[row]['cr_trip'].grid_remove()
         self.rows[row]['name'].grid(row=row+1, column=0)
         if cc.collapsed != CollapseMode.EXPANDED:
             self.rows[row]['demand']['text'] = '{:8,d}'.format(cc.unload())
@@ -257,12 +263,16 @@ class MainUi:
         self.rows[row]['cargo']['text'] = '{:8,d}'.format(i.cargo)
         self.rows[row]['carrier']['text'] = '{:8,d}'.format(i.carrier)
         self.rows[row]['buy']['text'] = '{:8,d}'.format(i.buy())
+        self.rows[row]['cr_ton']['text'] = '{:8,d}'.format(i.cr_ton)
+        self.rows[row]['cr_trip']['text'] = '{:8,d}'.format(i.cr_trip)
 
         self.rows[row]['name'].grid(row=row+1, column=0)
         self.rows[row]['buy'].grid(row=row + 1, column=1)
         self.rows[row]['demand'].grid(row=row+1, column=2)
         self.rows[row]['cargo'].grid(row=row+1, column=3)
         self.rows[row]['carrier'].grid(row=row+1, column=4)
+        self.rows[row]['cr_ton'].grid(row=row+1, column=5)
+        self.rows[row]['cr_trip'].grid(row=row+1, column=6)
 
         if i.buy() <= 0:
             self.rows[row]['name']['fg'] = 'green'
@@ -270,6 +280,8 @@ class MainUi:
             self.rows[row]['demand']['fg'] = 'green'
             self.rows[row]['cargo']['fg'] = 'green'
             self.rows[row]['carrier']['fg'] = 'green'
+            self.rows[row]['cr_ton']['fg'] = 'green'
+            self.rows[row]['cr_trip']['fg'] = 'green'
         else:
             fg_color = theme.current['foreground'] if theme.current else 'black'
             if i.available:
@@ -281,6 +293,8 @@ class MainUi:
             self.rows[row]['cargo']['fg'] = fg_color
             self.rows[row]['carrier']['fg'] = fg_color
             self.rows[row]['buy']['fg'] = fg_color
+            self.rows[row]['cr_ton']['fg'] = fg_color
+            self.rows[row]['cr_trip']['fg'] = fg_color
 
 
     def set_table(self, table: list[TableEntry], docked, isTotal: bool):


### PR DESCRIPTION
Adds 2 columns for profit per ton/item/unit and profit per trip of full cargo hold.
Also adds an option to not calculate these values, which leaves these new columns blank (as I wasn't able to figure out how to show/hide the columns via a settings ui entry)